### PR TITLE
Add docs and fix default transition

### DIFF
--- a/examples/state_machines/camera.rs
+++ b/examples/state_machines/camera.rs
@@ -81,7 +81,7 @@ event_driven_state_machine!(
         },
         event_enum: CameraEvent,
         event_trait: trait CameraEventTrait: Send {},
-        transitions: [
+        states: [
             Standby {
                 StartRecording -> Recording,
             },

--- a/examples/state_machines/http_request_builder.rs
+++ b/examples/state_machines/http_request_builder.rs
@@ -49,7 +49,7 @@ deterministic_state_machine!(
         context: HttpRequestBuilderData,
         // Optionally specify a trait that all states must implement
         state_trait: trait HttpRequestStateTrait {},
-        transitions: [
+        states: [
             NeedsMethod {
                 pub fn set_method(self, method: Method) -> HttpRequest<NeedsUrl> {
                     let Self { mut context, .. } = self;

--- a/examples/state_machines/traffic_light.rs
+++ b/examples/state_machines/traffic_light.rs
@@ -88,7 +88,7 @@ event_driven_state_machine!(
             fn color(&self) -> TrafficLightColor;
         },
         state_enum: #[derive(Debug)] #[derive(Clone)] TrafficLightMachineState,
-        transitions: [
+        states: [
             Red {
                 // From Red to Green when a TimeoutEvent occurs
                 TimeoutEvent {
@@ -154,8 +154,10 @@ event_driven_state_machine!(
                     println!("{:?}: Unhandled event: {:?}", Instant::now(), event);
                     state
                 }
-            }
+            },
         ],
+        // If we had events that weren't in the state blocks...
+        // events: [OtherEvent],
     }
 );
 

--- a/examples/traffic_light_with_camera.rs
+++ b/examples/traffic_light_with_camera.rs
@@ -88,7 +88,7 @@ event_driven_state_machine!(async TrafficLight {
     state_trait: trait TrafficLightStateTrait {},
     event_enum: TrafficLightEvent,
     event_trait: trait TrafficLightEventTrait: Send {},
-    transitions: [
+    states: [
         Red {
             Next -> Green,
             StopRecording {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-comment_width = 60
+comment_width = 80
 edition = "2021"
 format_code_in_doc_comments = true
 format_macro_matchers = true

--- a/src/deterministic_state_machine.rs
+++ b/src/deterministic_state_machine.rs
@@ -16,7 +16,7 @@ struct Machine {
     name: Ident,
     context: Path,
     state_trait: Option<ItemTrait>,
-    transitions: Vec<StateTransitions>,
+    state_transitions: Vec<StateTransitions>,
 }
 
 impl Parse for Machine {
@@ -31,6 +31,11 @@ impl Parse for Machine {
         let visibility = input
             .peek(Token![pub])
             .then(|| input.parse())
+            .transpose()?;
+
+        _ = input
+            .peek(Token![struct])
+            .then(|| input.parse::<Token![struct]>())
             .transpose()?;
 
         let name = input.parse()?;
@@ -53,7 +58,7 @@ impl Parse for Machine {
                 "state_trait" => {
                     state_trait = Some(content.parse()?);
                 }
-                "transitions" => {
+                "states" => {
                     let transitions_content;
                     _ = bracketed!(transitions_content in content);
                     let parsed_transitions =
@@ -106,7 +111,7 @@ impl Parse for Machine {
             name,
             context,
             state_trait,
-            transitions,
+            state_transitions: transitions,
         })
     }
 }
@@ -143,10 +148,10 @@ pub fn deterministic_state_machine(
         name,
         context,
         state_trait,
-        transitions,
+        state_transitions,
     } = parse_macro_input!(input as Machine);
 
-    let next_impls = transitions
+    let next_impls = state_transitions
         .into_iter()
         .map(|StateTransitions { state, transitions }| {
             quote! {

--- a/src/deterministic_state_machine.rs
+++ b/src/deterministic_state_machine.rs
@@ -45,7 +45,7 @@ impl Parse for Machine {
 
         let mut context = None;
         let mut state_trait = None;
-        let mut transitions = None;
+        let mut state_transitions = None;
 
         while content.peek(Ident) {
             let label: Ident = content.parse()?;
@@ -68,7 +68,7 @@ impl Parse for Machine {
                         >::parse_terminated(
                             &transitions_content,
                         )?;
-                    transitions = Some(
+                    state_transitions = Some(
                         parsed_transitions
                             .into_iter()
                             .collect::<Vec<_>>(),
@@ -98,12 +98,13 @@ impl Parse for Machine {
             )
         })?;
 
-        let transitions = transitions.ok_or_else(|| {
-            syn::Error::new(
-                input.span(),
-                "missing `transitions`",
-            )
-        })?;
+        let state_transitions = state_transitions
+            .ok_or_else(|| {
+                syn::Error::new(
+                    input.span(),
+                    "missing `states`",
+                )
+            })?;
 
         Ok(Self {
             attributes,
@@ -111,7 +112,7 @@ impl Parse for Machine {
             name,
             context,
             state_trait,
-            state_transitions: transitions,
+            state_transitions,
         })
     }
 }

--- a/src/event_driven_state_machine.rs
+++ b/src/event_driven_state_machine.rs
@@ -660,8 +660,22 @@ pub(super) fn event_driven_state_machine(
     };
 
     let unhandled_event = unhandled_event.map(|block| {
+        let function_ident = Ident::new(
+            "handle__unhandled_event",
+            block.span(),
+        );
+
         quote! {
-            (state, event) => #block
+            (state, event) => {
+                #[allow(non_snake_case)]
+                #asyncness fn #function_ident(
+                    mut state: #state_enum_ident,
+                    event: &mut #event_enum_ident,
+                    context: &mut #context_path,
+                ) -> impl Into<#state_enum_ident> #block
+                    
+                #function_ident(state, event, &mut self.context)#async_postfix.into()
+            }
         }
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,154 @@ pub fn event_driven_state_machine(
 }
 
 /// Build a deterministic finite state machine.
-/// Since the state machine is deterministic (i.e. there is
-/// only one possible transition for each state),
-/// the transitions are enforced at compile time.
+///
+/// Since the state machine is deterministic, transitions
+/// are enforced at compile time.
+///
+/// # Example
+/// The following example defines a simple traffic-light
+/// state machine. In each state, you can call the `change`
+/// method to transition to the next state. The context
+/// is updated with the number of times the light has
+/// changed.
+///
+/// ```rust
+/// # mod traffic_light {
+/// use machine_factory::deterministic_state_machine;
+///
+/// deterministic_state_machine! {
+///     #[derive(Debug)] // Attributes can optionally be added to the generated state machine's struct
+///     #[derive(Clone)] // Multiple attributes are allowed
+///     // Visibility and the struct keywords are also optional,
+///     // and are followed by a required Identifier for the state machine
+///     pub struct TrafficLight {
+///         // Path to the context for the state machine
+///         context: TrafficLightContext,
+///         // Optionally specify a trait that all states must implement
+///         state_trait: pub trait TrafficLightStateTrait {
+///             fn color(&self) -> String;
+///         },
+///         // List of states and their transitions
+///         states: [
+///             // Each state's transitions are defined as functions in a block,
+///             // similar to an impl block (which is what they expand to).
+///             Red {
+///                 pub fn change(self) -> TrafficLight<Green> {
+///                    let Self { mut context, .. } = self;
+///                    context.changes_count += 1;
+///                    TrafficLight { context, state: Green }
+///                 }
+///             },
+///             Yellow {
+///                 pub fn change(self) -> TrafficLight<Red> {
+///                     let Self { mut context, .. } = self;
+///                     context.changes_count += 1;
+///                     TrafficLight { context, state: Red }
+///                 }
+///
+///                 // You can transition to multiple states from a single state
+///                 // by defining multiple functions with different return types.
+///                 pub fn back_to_green(self) -> TrafficLight<Green> {
+///                     let Self { mut context, .. } = self;
+///                     context.changes_count += 1;
+///                     TrafficLight { context, state: Green }
+///                 }
+///             },
+///             Green {
+///                 pub fn change(self) -> TrafficLight<Yellow> {
+///                     let Self { mut context, .. } = self;
+///                     context.changes_count += 1;
+///                     TrafficLight { context, state: Yellow }
+///                 }
+///
+///                 // You can also define state-specific methods;
+///                 // it isn't required that a transition occurs.
+///                 // This function is only available when the
+///                 // traffic-light is in the Green state.
+///                 pub fn car_passed(&mut self) {
+///                     self.context.car_count += 1;
+///                 }
+///             },
+///         ],
+///     }
+/// }
+///
+/// // The context for the state machine.
+/// #[derive(Debug, Clone)]
+/// pub struct TrafficLightContext {
+///     pub changes_count: u32,
+///     pub car_count: u32,
+/// }
+///
+/// // These are the states for the traffic light.
+/// // They can have fields of their own, but, in this case, they don't.
+///
+/// pub struct Red;
+/// pub struct Yellow;
+/// pub struct Green;
+///
+/// // Since we specified the `TrafficLightStateTrait` trait, we must implement it for each state.
+///
+/// impl TrafficLightStateTrait for Red {
+///     fn color(&self) -> String {
+///         "Red".to_owned()
+///     }
+/// }
+///
+/// impl TrafficLightStateTrait for Yellow {
+///     fn color(&self) -> String {
+///         "Yellow".to_owned()
+///     }
+/// }
+///
+/// impl TrafficLightStateTrait for Green {
+///     fn color(&self) -> String {
+///         "Green".to_owned()
+///     }
+/// }
+/// # }
+///
+/// // Now we can use the state machine.
+/// # use traffic_light::*;
+///
+/// // Create a new traffic light in the Red state, with a starting context.
+/// let traffic_light = TrafficLight::new(Red, TrafficLightContext {
+///     changes_count: 0,
+///     car_count: 0,
+/// });
+///
+/// // We can access the context and state of the traffic light
+/// // using the `context` and `state` methods, which return immutable references.
+/// assert_eq!(traffic_light.context().changes_count, 0);
+/// assert_eq!(traffic_light.context().car_count, 0);
+/// assert_eq!(traffic_light.state().color(), "Red");
+///
+/// // Change the light to Green.
+/// let mut traffic_light = traffic_light.change();
+/// assert_eq!(traffic_light.context().changes_count, 1);
+/// assert_eq!(traffic_light.context().car_count, 0);
+/// assert_eq!(traffic_light.state().color(), "Green");
+///
+/// // A car passes, incrementing the car count.
+/// traffic_light.car_passed();
+/// assert_eq!(traffic_light.context().car_count, 1);
+///
+/// // Change the light to Yellow.
+/// let traffic_light = traffic_light.change();
+/// assert_eq!(traffic_light.context().changes_count, 2);
+/// assert_eq!(traffic_light.context().car_count, 1);
+/// assert_eq!(traffic_light.state().color(), "Yellow");
+///
+/// // This is a magic traffic-light where cars only pass when it's green,
+/// // so we can't call `car_passed` here.
+/// // traffic_light.car_passed();
+///
+/// // Change the light back to Green.
+/// let traffic_light = traffic_light.back_to_green();
+/// assert_eq!(traffic_light.context().changes_count, 3);
+/// assert_eq!(traffic_light.context().car_count, 1);
+/// assert_eq!(traffic_light.state().color(), "Green");
+/// ```
 #[proc_macro]
 pub fn deterministic_state_machine(
     input: TokenStream,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ mod state_trait;
 ///             // You can optionally define a catch-all transition that applies to all state/event pairs not explicitly defined.
 ///             _ {
 ///                 if let TrafficLightEvent::EmergencyVehicleApproaching(EmergencyVehicleApproaching { requested_color }) = event {
-///                     self.context.in_emergency = true;
+///                     context.in_emergency = true;
 ///                     TrafficLightState::from(*requested_color)
 ///                 } else {
 ///                     // We are going to remain in the same state.


### PR DESCRIPTION
- Add docs
- Fix issue with default transition not having a generated fn that restricts access to state/context/event
- Slight adjustments to the macros that became apparently needed when making the docs


Closes: #6 